### PR TITLE
Add unit-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "itertools",
+ "num",
 ]
 
 [[package]]
@@ -123,6 +124,82 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.2.13", features = ["derive"] }
 itertools = "0.10.3"
+num = "0.4.0"

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ Root
 ##Grandchild 2
 ```
 
-`#` indicates a nested child.
+Here, `#` indicates a nested child.
 
 With the above content in a file `examples/with_grandchildren.txt`, we can render the tree like this:
 
@@ -30,4 +30,32 @@ cargo run -- --input examples/with_grandchildren.txt
 ┌──────┴───────┐  ┌──────┴───────┐
 │ Grandchild 1 │  │ Grandchild 2 │
 └──────────────┘  └──────────────┘
+```
+
+## Development
+
+### Install Rust
+
+```
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+See details in https://www.rust-lang.org/tools/install.
+
+### Run Unittest
+
+```
+cargo test
+```
+
+### Add Libraries
+
+```
+cargo add <DEP>[@<VERSION>] ...
+```
+
+e.g.
+
+```
+cargo add num
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,18 +8,6 @@ use clap::Parser;
 mod parser;
 mod tree;
 
-const THIN: BoxDrawings = BoxDrawings {
-    up_and_left: '┌',
-    up_and_right: '┐',
-    down_and_left: '└',
-    down_and_right: '┘',
-    vertical: '│',
-    horizontal: '─',
-    vertical_and_horizontal: '┼',
-    down_and_horizontal: '┬',
-    up_and_horizontal: '┴',
-};
-
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
 struct Args {
@@ -30,19 +18,8 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-
     let root = parse(args.input);
-
     let drawable_root = DrawableTreeNode::new(root.borrow());
-
-    let mut canvas: Vec<Vec<char>> =
-        vec![vec![' '; drawable_root.overall_width]; drawable_root.overall_height];
-
-    drawable_root.render(&mut canvas, THIN);
-    let result = canvas
-        .iter()
-        .map(|row| row.iter().collect())
-        .collect::<Vec<String>>()
-        .join("\n");
+    let result = drawable_root.render(&BoxDrawings::THIN);
     println!("{}", result);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,10 +12,7 @@ pub fn parse(filename: String) -> Rc<RefCell<TreeNode>> {
 
     let lines: Vec<&str> = contents.split("\n").collect();
 
-    let root = Rc::new(RefCell::new(TreeNode {
-        label: lines[0].to_string(),
-        children: vec![],
-    }));
+    let root = Rc::new(RefCell::new(TreeNode::from_label(lines[0])));
 
     let mut stack: Vec<Rc<RefCell<TreeNode>>> = vec![root.clone()];
 
@@ -37,10 +34,7 @@ pub fn parse(filename: String) -> Rc<RefCell<TreeNode>> {
             let _ = &stack.pop();
         }
 
-        let node = TreeNode {
-            label: grouped_parts[1].to_string(),
-            children: vec![],
-        };
+        let node = TreeNode::from_label(&grouped_parts[1]);
 
         let new_child = Rc::new(RefCell::new(node));
 

--- a/src/tree/style.rs
+++ b/src/tree/style.rs
@@ -9,3 +9,16 @@ pub struct BoxDrawings {
     pub down_and_horizontal: char,
     pub up_and_horizontal: char,
 }
+impl BoxDrawings {
+    pub const THIN: BoxDrawings = BoxDrawings {
+        up_and_left: '┌',
+        up_and_right: '┐',
+        down_and_left: '└',
+        down_and_right: '┘',
+        vertical: '│',
+        horizontal: '─',
+        vertical_and_horizontal: '┼',
+        down_and_horizontal: '┬',
+        up_and_horizontal: '┴',
+    };
+}

--- a/src/tree/tree_node.rs
+++ b/src/tree/tree_node.rs
@@ -1,9 +1,28 @@
-use std::rc::Rc;
-
 use std::cell::RefCell;
+use std::rc::Rc;
 
 #[derive(Debug)]
 pub struct TreeNode {
     pub label: String,
     pub children: Vec<Rc<RefCell<TreeNode>>>,
+}
+
+impl TreeNode {
+    pub fn from_label(label: &str) -> Self {
+        TreeNode {
+            label: label.to_string(),
+            children: Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new(label: &str, children: Vec<TreeNode>) -> Self {
+        TreeNode {
+            label: label.to_string(),
+            children: children
+                .into_iter()
+                .map(|child| Rc::new(RefCell::new(child)))
+                .collect(),
+        }
+    }
 }


### PR DESCRIPTION
```
$ cargo test -- --nocapture
   Compiling ascii_tree v0.1.0 (/Users/yuchen/Documents/ascii_tree)
    Finished test [unoptimized + debuginfo] target(s) in 0.78s
     Running unittests src/main.rs (target/debug/deps/ascii_tree-1efa9b73dc534b5e)

running 5 tests
test tree::drawable::tests::test_single_root ... ok
test tree::drawable::tests::test_root_plus_one_child ... ok
test tree::drawable::tests::test_root_with_two_children ... ok
test tree::drawable::tests::test_root_with_three_children ... ok
test tree::drawable::tests::test_root_with_grandchildren ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```