### PR TITLE
Remove Use of Rc and RefCell

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ struct Args {
 fn main() {
     let args = Args::parse();
     let root = parse(args.input);
-    let drawable_root = DrawableTreeNode::new(root.borrow());
+    let drawable_root = DrawableTreeNode::new(&root);
     let result = drawable_root.render(&BoxDrawings::THIN);
     println!("{}", result);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -31,6 +31,93 @@ fn parse_line(line: &str) -> (usize, String) {
     (grouped_parts[0].len() - 1, grouped_parts[1].clone())
 }
 
+fn parse_line2(line: &str) -> (usize, String) {
+    let grouped_parts: Vec<String> = line
+        .to_string()
+        .chars()
+        .group_by(|&x| x == '#')
+        .into_iter()
+        .map(|(_, r)| r.collect())
+        .collect();
+
+    let count_pound_signs = grouped_parts[0].len();
+    let label = grouped_parts[1].trim();
+    (count_pound_signs, label.to_string())
+}
+
+#[derive(Debug)]
+pub struct TreeNode2 {
+    pub label: String,
+    pub children: Vec<TreeNode2>,
+}
+
+impl TreeNode2 {
+    pub fn from_label_str(label: &str) -> Self {
+        TreeNode2 {
+            label: label.to_string(),
+            children: vec![],
+        }
+    }
+
+    pub fn from_label(label: String) -> Self {
+        TreeNode2 {
+            label: label,
+            children: vec![],
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new(label: &str, children: Vec<TreeNode2>) -> Self {
+        TreeNode2 {
+            label: label.to_string(),
+            children: children,
+        }
+    }
+}
+
+fn parse_markdown(content: String) -> TreeNode2 {
+    let lines: Vec<&str> = content
+        .split("\n")
+        .map(|x| x.trim())
+        .filter(|&x| !x.is_empty())
+        .filter(|&x| x.starts_with("#"))
+        .collect();
+
+    let (_depth, label) = parse_line2(lines[0]);
+
+    let root = TreeNode2::from_label(label);
+
+    let mut stack: Vec<Vec<TreeNode2>> = vec![vec![root]];
+
+    for line in &lines[1..] {
+        let (depth, label) = parse_line2(line);
+
+        while depth < stack.len() {
+            let children = stack.pop().unwrap();
+            stack.last_mut().unwrap().last_mut().unwrap().children = children;
+        }
+
+        let node = TreeNode2::from_label(label);
+        if depth > stack.len() {
+            stack.push(vec![node]);
+        } else {
+            assert_eq!(depth, stack.len());
+            stack.last_mut().unwrap().push(node);
+        }
+    }
+
+    while stack.len() > 1 {
+        let children = stack.pop().unwrap();
+        stack.last_mut().unwrap().last_mut().unwrap().children = children;
+    }
+
+    assert_eq!(stack.len(), 1);
+    let mut root_layer = stack.pop().unwrap();
+
+    assert_eq!(root_layer.len(), 1);
+    root_layer.pop().unwrap()
+}
+
 fn parse_content(content: String) -> Rc<RefCell<TreeNode>> {
     let lines: Vec<&str> = content.split("\n").filter(|&x| !x.is_empty()).collect();
 
@@ -41,7 +128,6 @@ fn parse_content(content: String) -> Rc<RefCell<TreeNode>> {
     let mut stack: Vec<Rc<RefCell<TreeNode>>> = vec![root.clone()];
 
     for line in &lines[1..] {
-
         let (depth, label) = parse_line(line);
 
         while depth < stack.len() {
@@ -72,14 +158,19 @@ mod tests {
         let actual = parse_line("#Root");
         assert_eq!(actual, (0, "Root".to_owned()))
     }
+    
+    #[test]
+    fn test_parse_line_with_with_space() {
+        let actual = parse_line2("# Hello World ");
+        assert_eq!(actual, (1, "Hello World".to_owned()))
+    }
 
     #[test]
-    fn test_parse_content_root_only() {
+    fn test_parse_content_root() {
         let node = parse_content("#Root\n".to_string());
 
         assert_eq!(node.borrow().label, "Root");
         assert_eq!(node.borrow().children.len(), 0);
-
     }
 
     #[test]
@@ -88,5 +179,43 @@ mod tests {
 
         assert_eq!(node.borrow().label, "Root");
         assert_eq!(node.borrow().children.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_markdown_root() {
+        let node = parse_markdown("#Root\n".to_string());
+
+        assert_eq!(node.label, "Root");
+        assert_eq!(node.children.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_markdown_ignore_none_title_lines() {
+        // Both empty lines and none-title lines are ignored
+        let node = parse_markdown(
+            r#"
+            #Root
+            hello world
+            "#
+            .to_string(),
+        );
+
+        assert_eq!(node.label, "Root");
+        assert_eq!(node.children.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_markdown_root_with_children() {
+        let node = parse_markdown(
+            r#"
+            #Root
+            ##Child1
+            ##Child2
+            "#
+            .to_string(),
+        );
+
+        assert_eq!(node.label, "Root");
+        assert_eq!(node.children.len(), 2);
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -83,7 +83,7 @@ mod tests {
         let actual = parse_line("#Root");
         assert_eq!(actual, (1, "Root".to_owned()))
     }
-    
+
     #[test]
     fn test_parse_line_with_with_space() {
         let actual = parse_line("# Hello World ");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,18 +26,6 @@ fn parse_line(line: &str) -> (usize, String) {
         .map(|(_, r)| r.collect())
         .collect();
 
-    (grouped_parts[0].len() - 1, grouped_parts[1].clone())
-}
-
-fn parse_line2(line: &str) -> (usize, String) {
-    let grouped_parts: Vec<String> = line
-        .to_string()
-        .chars()
-        .group_by(|&x| x == '#')
-        .into_iter()
-        .map(|(_, r)| r.collect())
-        .collect();
-
     let count_pound_signs = grouped_parts[0].len();
     let label = grouped_parts[1].trim();
     (count_pound_signs, label.to_string())
@@ -51,14 +39,14 @@ fn parse_markdown(content: String) -> TreeNode {
         .filter(|&x| x.starts_with("#"))
         .collect();
 
-    let (_depth, label) = parse_line2(lines[0]);
+    let (_depth, label) = parse_line(lines[0]);
 
     let root = TreeNode::from_label(label);
 
     let mut stack: Vec<Vec<TreeNode>> = vec![vec![root]];
 
     for line in &lines[1..] {
-        let (depth, label) = parse_line2(line);
+        let (depth, label) = parse_line(line);
 
         while depth < stack.len() {
             let children = stack.pop().unwrap();
@@ -93,12 +81,12 @@ mod tests {
     #[test]
     fn test_parse_line() {
         let actual = parse_line("#Root");
-        assert_eq!(actual, (0, "Root".to_owned()))
+        assert_eq!(actual, (1, "Root".to_owned()))
     }
     
     #[test]
     fn test_parse_line_with_with_space() {
-        let actual = parse_line2("# Hello World ");
+        let actual = parse_line("# Hello World ");
         assert_eq!(actual, (1, "Hello World".to_owned()))
     }
 

--- a/src/point2d.rs
+++ b/src/point2d.rs
@@ -1,5 +1,0 @@
-#[derive(Debug)]
-pub struct Point2D<T> {
-    pub x: T,
-    pub y: T,
-}

--- a/src/tree/drawable.rs
+++ b/src/tree/drawable.rs
@@ -324,7 +324,7 @@ mod tests {
     }
 
     #[test]
-    fn test_single_root() {
+    fn test_root() {
         let root = TreeNode::from_label("root");
         let drawable_root = DrawableTreeNode::new(RefCell::new(root).borrow());
         let result = drawable_root.render(&BoxDrawings::THIN);
@@ -336,7 +336,7 @@ mod tests {
     }
 
     #[test]
-    fn test_root_plus_one_child() {
+    fn test_root_with_one_child() {
         let child1 = TreeNode::from_label("child1");
         let root = TreeNode::new("root", vec![child1]);
 

--- a/src/tree/drawable.rs
+++ b/src/tree/drawable.rs
@@ -2,7 +2,6 @@ use crate::tree::style::BoxDrawings;
 use crate::tree::tree_node::TreeNode;
 extern crate num;
 use num::Zero;
-use std::cell::Ref;
 use std::cmp::max;
 
 static HORIZONTAL_CHILDREN_BUFFER: usize = 2;
@@ -44,7 +43,7 @@ pub struct DrawableTreeNode {
 }
 
 impl DrawableTreeNode {
-    pub fn new(node: Ref<TreeNode>) -> Self {
+    pub fn new(node: &TreeNode) -> Self {
         // A space on both side, and two vertical bars, i.e.:
         // ┌──────┐
         // │ Root │
@@ -57,7 +56,7 @@ impl DrawableTreeNode {
         let drawable_children: Vec<DrawableTreeNode> = node
             .children
             .iter()
-            .map(|x| DrawableTreeNode::new(x.borrow()))
+            .map(|x| DrawableTreeNode::new(x))
             .collect();
 
         let children_width: usize = if node.children.len() == 0 {
@@ -268,7 +267,6 @@ impl DrawableTreeNode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::RefCell;
 
     fn assert_eq(left: &String, right: &str) {
         let left_rows = left.split('\n').collect::<Vec<&str>>();
@@ -325,8 +323,8 @@ mod tests {
 
     #[test]
     fn test_root() {
-        let root = TreeNode::from_label("root");
-        let drawable_root = DrawableTreeNode::new(RefCell::new(root).borrow());
+        let root = TreeNode::from_label_str("root");
+        let drawable_root = DrawableTreeNode::new(&root);
         let result = drawable_root.render(&BoxDrawings::THIN);
         let expected = r#"
         ┌──────┐
@@ -337,10 +335,10 @@ mod tests {
 
     #[test]
     fn test_root_with_one_child() {
-        let child1 = TreeNode::from_label("child1");
+        let child1 = TreeNode::from_label_str("child1");
         let root = TreeNode::new("root", vec![child1]);
 
-        let drawable_root = DrawableTreeNode::new(RefCell::new(root).borrow());
+        let drawable_root = DrawableTreeNode::new(&root);
         let result = drawable_root.render(&BoxDrawings::THIN);
 
         let expected = r#"
@@ -355,11 +353,11 @@ mod tests {
 
     #[test]
     fn test_root_with_two_children() {
-        let child1 = TreeNode::from_label("child1");
-        let child2 = TreeNode::from_label("child2");
+        let child1 = TreeNode::from_label_str("child1");
+        let child2 = TreeNode::from_label_str("child2");
         let root = TreeNode::new("root", vec![child1, child2]);
 
-        let drawable_root = DrawableTreeNode::new(RefCell::new(root).borrow());
+        let drawable_root = DrawableTreeNode::new(&root);
         let result = drawable_root.render(&BoxDrawings::THIN);
 
         let expected = r#"
@@ -375,12 +373,12 @@ mod tests {
 
     #[test]
     fn test_root_with_three_children() {
-        let child1 = TreeNode::from_label("child1");
-        let child2 = TreeNode::from_label("child2");
-        let child3 = TreeNode::from_label("child3");
+        let child1 = TreeNode::from_label_str("child1");
+        let child2 = TreeNode::from_label_str("child2");
+        let child3 = TreeNode::from_label_str("child3");
         let root = TreeNode::new("root", vec![child1, child2, child3]);
 
-        let drawable_root = DrawableTreeNode::new(RefCell::new(root).borrow());
+        let drawable_root = DrawableTreeNode::new(&root);
         let result = drawable_root.render(&BoxDrawings::THIN);
 
         let expected = r#"
@@ -396,16 +394,16 @@ mod tests {
 
     #[test]
     fn test_root_with_grandchildren() {
-        let grandchild1 = TreeNode::from_label("grandchild1");
-        let grandchild2 = TreeNode::from_label("grandchild2");
-        let grandchild3 = TreeNode::from_label("grandchild3");
+        let grandchild1 = TreeNode::from_label_str("grandchild1");
+        let grandchild2 = TreeNode::from_label_str("grandchild2");
+        let grandchild3 = TreeNode::from_label_str("grandchild3");
 
         let child1 = TreeNode::new("child1", vec![grandchild1, grandchild2]);
         let child2 = TreeNode::new("child2", vec![grandchild3]);
 
         let root = TreeNode::new("root", vec![child1, child2]);
 
-        let drawable_root = DrawableTreeNode::new(RefCell::new(root).borrow());
+        let drawable_root = DrawableTreeNode::new(&root);
         let result = drawable_root.render(&BoxDrawings::THIN);
 
         let expected = r#"

--- a/src/tree/tree_node.rs
+++ b/src/tree/tree_node.rs
@@ -1,17 +1,21 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-
 #[derive(Debug)]
 pub struct TreeNode {
     pub label: String,
-    pub children: Vec<Rc<RefCell<TreeNode>>>,
+    pub children: Vec<TreeNode>,
 }
 
 impl TreeNode {
-    pub fn from_label(label: &str) -> Self {
+    pub fn from_label_str(label: &str) -> Self {
         TreeNode {
             label: label.to_string(),
-            children: Vec::new(),
+            children: vec![],
+        }
+    }
+
+    pub fn from_label(label: String) -> Self {
+        TreeNode {
+            label: label,
+            children: vec![],
         }
     }
 
@@ -19,10 +23,7 @@ impl TreeNode {
     pub fn new(label: &str, children: Vec<TreeNode>) -> Self {
         TreeNode {
             label: label.to_string(),
-            children: children
-                .into_iter()
-                .map(|child| Rc::new(RefCell::new(child)))
-                .collect(),
+            children: children,
         }
     }
 }

--- a/src/tree/tree_node.rs
+++ b/src/tree/tree_node.rs
@@ -5,6 +5,7 @@ pub struct TreeNode {
 }
 
 impl TreeNode {
+    #[cfg(test)]
     pub fn from_label_str(label: &str) -> Self {
         TreeNode {
             label: label.to_string(),


### PR DESCRIPTION
By changing the parser, we don't need to use `Rc` and `RefCell` in the `TreeNode` definition.


```
[7:54:40] yuchen:ascii_tree git:(remove_rc_rfcell*) $ cargo test -- --nocapture
   Compiling ascii_tree v0.1.0 (/Users/yuchen/Documents/ascii_tree)
    Finished test [unoptimized + debuginfo] target(s) in 0.64s
     Running unittests src/main.rs (target/debug/deps/ascii_tree-1efa9b73dc534b5e)

running 10 tests
test parser::tests::test_parse_line ... ok
test parser::tests::test_parse_line_with_with_space ... ok
test parser::tests::test_parse_markdown_root ... ok
test parser::tests::test_parse_markdown_ignore_none_title_lines ... ok
test parser::tests::test_parse_markdown_root_with_children ... ok
test tree::drawable::tests::test_root ... ok
test tree::drawable::tests::test_root_with_one_child ... ok
test tree::drawable::tests::test_root_with_grandchildren ... ok
test tree::drawable::tests::test_root_with_three_children ... ok
test tree::drawable::tests::test_root_with_two_children ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

```
$ cargo run -- --input examples/with_grandchildren.md

   Compiling ascii_tree v0.1.0 (/Users/yuchen/Documents/ascii_tree)
    Finished dev [unoptimized + debuginfo] target(s) in 0.61s
     Running `target/debug/ascii_tree --input examples/with_grandchildren.md`
             ┌──────┐             
             │ Root │             
             └──┬───┘             
           ┌────┴────┐            
           │ Child 1 │            
           └────┬────┘            
       ┌────────┴────────┐        
┌──────┴───────┐  ┌──────┴───────┐
│ Grandchild 1 │  │ Grandchild 2 │
└──────────────┘  └──────────────┘
```