### PR TITLE
Support parsing & drawing multiple tree in one markdown file

### DIFF
--- a/examples/multi_tree.md
+++ b/examples/multi_tree.md
@@ -1,0 +1,7 @@
+# Root
+## Child 1
+### Grandchild 1.1
+### Grandchild 1.2
+## Child 2
+# Roo 2
+## Child 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,9 +45,9 @@ pub struct HorizontalArgs {
 
 impl HorizontalArgs {
     fn run(&self) {
-        let root = parse(&self.input);
+        let root_nodes = parse(&self.input);
         println!(".");
-        horizontal::print_nodes(&vec![root], "")
+        horizontal::print_nodes(&root_nodes, "")
     }
 }
 
@@ -69,14 +69,16 @@ pub struct VerticalArgs {
 
 impl VerticalArgs {
     fn run(self) {
-        let root = parse(&self.input);
-        let drawable_root = DrawableTreeNode::new(&root);
-        let result = drawable_root.render(
-            &BoxDrawings::new(self.style),
-            self.top_connection,
-            self.bottom_connection,
-        );
-        println!("{}", result);
+        let root_nodes = parse(&self.input);
+        for root in root_nodes {
+            let drawable_root = DrawableTreeNode::new(&root);
+            let result = drawable_root.render(
+                &BoxDrawings::new(self.style),
+                self.top_connection,
+                self.bottom_connection,
+            );
+            println!("{}", result);
+        }
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -94,16 +94,16 @@ mod tests {
 
     #[test]
     fn test_parse_markdown_root() {
-        let node = parse_markdown("#Root\n".to_string());
-
-        assert_eq!(node.label, "Root");
-        assert_eq!(node.children.len(), 0);
+        let nodes = parse_markdown("#Root\n".to_string());
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].label, "Root");
+        assert_eq!(nodes[0].children.len(), 0);
     }
 
     #[test]
     fn test_parse_markdown_ignore_none_title_lines() {
         // Both empty lines and none-title lines are ignored
-        let node = parse_markdown(
+        let nodes = parse_markdown(
             r#"
             #Root
             hello world
@@ -111,13 +111,14 @@ mod tests {
             .to_string(),
         );
 
-        assert_eq!(node.label, "Root");
-        assert_eq!(node.children.len(), 0);
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].label, "Root");
+        assert_eq!(nodes[0].children.len(), 0);
     }
 
     #[test]
     fn test_parse_markdown_root_with_children() {
-        let node = parse_markdown(
+        let nodes = parse_markdown(
             r#"
             #Root
             ##Child1
@@ -126,7 +127,30 @@ mod tests {
             .to_string(),
         );
 
-        assert_eq!(node.label, "Root");
-        assert_eq!(node.children.len(), 2);
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].label, "Root");
+        assert_eq!(nodes[0].children.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_markdown_multiple_roots() {
+        let nodes = parse_markdown(
+            r#"
+            # Root 1
+            ## Child 1.1
+            ## Child 1.2
+            # Root 2
+            ## Child 2.1
+            "#
+            .to_string(),
+        );
+
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].label, "Root 1");
+        assert_eq!(nodes[0].children.len(), 2);
+
+        assert_eq!(nodes[1].label, "Root 2");
+        assert_eq!(nodes[1].children.len(), 1);
+        assert_eq!(nodes[1].children[0].label, "Child 2.1");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -67,6 +67,7 @@ fn parse_markdown(content: String) -> Vec<TreeNode> {
                 nodes: vec![node],
             });
         } else {
+            assert_eq!(depth, stack.last().unwrap().depth);
             stack.last_mut().unwrap().nodes.push(node);
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,7 @@ use crate::tree::tree_node::TreeNode;
 use itertools::Itertools;
 use std::fs;
 
-pub fn parse(filename: &String) -> TreeNode {
+pub fn parse(filename: &String) -> Vec<TreeNode> {
     let content: String = fs::read_to_string(filename.clone())
         .expect(format!("Fail to read input file {}", filename).as_str());
 
@@ -31,7 +31,7 @@ fn parse_line(line: &str) -> (usize, String) {
     (count_pound_signs, label.to_string())
 }
 
-fn parse_markdown(content: String) -> TreeNode {
+fn parse_markdown(content: String) -> Vec<TreeNode> {
     let lines: Vec<&str> = content
         .split("\n")
         .map(|x| x.trim())
@@ -39,14 +39,15 @@ fn parse_markdown(content: String) -> TreeNode {
         .filter(|&x| x.starts_with("#"))
         .collect();
 
-    let (_depth, label) = parse_line(lines[0]);
-
-    let root = TreeNode::from_label(label);
+    // Create a dummy node at depth 0
+    let root = TreeNode::from_label_str("[DUMMY]");
 
     let mut stack: Vec<Vec<TreeNode>> = vec![vec![root]];
 
-    for line in &lines[1..] {
-        let (depth, label) = parse_line(line);
+    for line in &lines {
+        let (mut depth, label) = parse_line(line);
+
+        depth += 1;
 
         while depth < stack.len() {
             let children = stack.pop().unwrap();
@@ -71,7 +72,8 @@ fn parse_markdown(content: String) -> TreeNode {
     let mut root_layer = stack.pop().unwrap();
 
     assert_eq!(root_layer.len(), 1);
-    root_layer.pop().unwrap()
+    let dummy_root = root_layer.pop().unwrap();
+    dummy_root.children
 }
 
 #[cfg(test)]

--- a/src/tree/style.rs
+++ b/src/tree/style.rs
@@ -1,4 +1,4 @@
-#[derive(clap::ArgEnum, Clone, Debug)]
+#[derive(clap::ArgEnum, Debug, Clone, Copy)]
 pub enum Style {
     Thin,
     Thick,

--- a/src/tree/tree_node.rs
+++ b/src/tree/tree_node.rs
@@ -5,7 +5,6 @@ pub struct TreeNode {
 }
 
 impl TreeNode {
-    #[cfg(test)]
     pub fn from_label_str(label: &str) -> Self {
         TreeNode {
             label: label.to_string(),


### PR DESCRIPTION
```
cargo run -- vertical -i examples/multi_tree.md
                            ┌──────┐
                            │ Root │
                            └──┬───┘
                  ┌────────────┴─────────────┐
             ┌────┴────┐                ┌────┴────┐
             │ Child 1 │                │ Child 2 │
             └────┬────┘                └─────────┘
        ┌─────────┴─────────┐
┌───────┴────────┐  ┌───────┴────────┐
│ Grandchild 1.1 │  │ Grandchild 1.2 │
└────────────────┘  └────────────────┘
 ┌───────┐
 │ Roo 2 │
 └───┬───┘
┌────┴────┐
│ Child 3 │
└─────────┘
```

```
$ cargo run -- horizontal -i examples/multi_tree.md
.
├─ Root
│  ├─ Child 1
│  │  ├─ Grandchild 1.1
│  │  └─ Grandchild 1.2
│  └─ Child 2
└─ Roo 2
   └─ Child 3
```