### PR TITLE
Fix: tree render when parent is wider than child

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'astree'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=astree",
+                    "--package=astree"
+                ],
+                "filter": {
+                    "name": "astree",
+                    "kind": "bin"
+                }
+            },
+            "args": ["vertical", "-i", "examples/with_grandchildren_0.md"],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'astree'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=astree",
+                    "--package=astree"
+                ],
+                "filter": {
+                    "name": "astree",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "astree"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "astree"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "clap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astree"
-version = "0.2.2"
+version = "0.2.3"
 license = "MIT OR Apache-2.0"
 description = " A command line tool for drawing tree structures with ascii characters"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "astree"
 version = "0.2.2"
-authors = ["Yuchen Zhong <yuchen.post@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = " A command line tool for drawing tree structures with ascii characters"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astree"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Yuchen Zhong <yuchen.post@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = " A command line tool for drawing tree structures with ascii characters"

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,32 @@ A command line tool for drawing tree structures with ascii characters.
 
 ## Usage
 
-Install from crates.io <https://crates.io/crates/astree> with `cargo install astree`.
+Install from crates.io <https://crates.io/crates/astree>:
+
+```
+cargo install astree
+```
+
+Check out the help message:
+
+```
+$ astree --help
+
+astree 0.2.2
+ A command line tool for drawing tree structures with ascii characters
+
+USAGE:
+    astree <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    help          Print this message or the help of the given subcommand(s)
+    horizontal    Print the tree horizontally
+    vertical      Print the tree virtually
+```
 
 Create an input file following the markdown syntax, such as:
 

--- a/readme.md
+++ b/readme.md
@@ -100,22 +100,6 @@ astree vertical --input examples/with_grandchildren_1.md --style double
 ╚══════════════╝  ╚══════════════╝
 ```
 
-With special top connection:
-
-```
-astree vertical --input examples/with_grandchildren_1.md --top-connection ▼
-             ┌──────┐
-             │ Root │
-             └──┬───┘
-           ┌────▼────┐
-           │ Child 1 │
-           └────┬────┘
-       ┌────────┴────────┐
-┌──────▼───────┐  ┌──────▼───────┐
-│ Grandchild 1 │  │ Grandchild 2 │
-└──────────────┘  └──────────────┘
-```
-
 With chest style:
 
 ```
@@ -138,12 +122,12 @@ astree vertical --input examples/with_grandchildren_2.md --style chest
 With balloon style:
 
 ```
-astree vertical --input examples/with_children_2.md --style balloon --top-connection ☐ --bottom-connection ┰
-   ╭───────────╮
-   │ Root Node │
-   ╰─────┰─────╯
-    ╭────┴─────╮
-╭───☐───╮  ╭───☐───╮
+astree vertical --input examples/with_children_2.md --style balloon --top-connection ¤ --bottom-connection ¤ 
+   ╭───────────╮    
+   │ Root Node │    
+   ╰─────¤─────╯    
+    ╭────┴─────╮    
+╭───¤───╮  ╭───¤───╮
 │ Child │  │ Child │
 │  (1)  │  │  (2)  │
 ╰───────╯  ╰───────╯

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,7 +47,7 @@ fn parse_markdown(content: String) -> Vec<TreeNode> {
     // Create a dummy root node at depth 0
     let root_layer = NodeLayer {
         depth: 0,
-        nodes: vec![TreeNode::from_label_str("[DUMMY]")],
+        nodes: vec![TreeNode::from_label("[DUMMY]")],
     };
 
     let mut stack: Vec<NodeLayer> = vec![root_layer];
@@ -60,7 +60,7 @@ fn parse_markdown(content: String) -> Vec<TreeNode> {
             stack.last_mut().unwrap().nodes.last_mut().unwrap().children = top_layer.nodes;
         }
 
-        let node = TreeNode::from_label(label);
+        let node = TreeNode::from_label(&label);
         if depth > stack.last().unwrap().depth {
             stack.push(NodeLayer {
                 depth: depth,

--- a/src/tree/tree_node.rs
+++ b/src/tree/tree_node.rs
@@ -5,16 +5,9 @@ pub struct TreeNode {
 }
 
 impl TreeNode {
-    pub fn from_label_str(label: &str) -> Self {
+    pub fn from_label(label: &str) -> Self {
         TreeNode {
             label: label.to_string(),
-            children: vec![],
-        }
-    }
-
-    pub fn from_label(label: String) -> Self {
-        TreeNode {
-            label: label,
             children: vec![],
         }
     }

--- a/src/tree/vertical.rs
+++ b/src/tree/vertical.rs
@@ -571,6 +571,42 @@ mod layout_tests {
              │ child │      
              └───────┘      "#;
         assert_eq(&result, &expected);
+
+
+
+        let children = vec![TreeNode::from_label("a"), TreeNode::from_label("b")];
+        let root = TreeNode::new("a long root node", children);
+
+        let drawable_root = DrawableTreeNode::new(&root);
+        let result = drawable_root.render(&BoxDrawings::THIN, None, None);
+
+        let expected = r#"
+        ┌──────────────────┐
+        │ a long root node │
+        └────────┬─────────┘
+              ┌──┴───┐      
+            ┌─┴─┐  ┌─┴─┐    
+            │ a │  │ b │    
+            └───┘  └───┘    "#;
+        assert_eq(&result, &expected);
+
+
+
+        let children = vec![TreeNode::from_label("a"), TreeNode::from_label("b"), TreeNode::from_label("c")];
+        let root = TreeNode::new("a long root node", children);
+
+        let drawable_root = DrawableTreeNode::new(&root);
+        let result = drawable_root.render(&BoxDrawings::THIN, None, None);
+
+        let expected = r#"
+        ┌──────────────────┐
+        │ a long root node │
+        └────────┬─────────┘
+          ┌──────┼──────┐   
+        ┌─┴─┐  ┌─┴─┐  ┌─┴─┐ 
+        │ a │  │ b │  │ c │ 
+        └───┘  └───┘  └───┘ "#;
+        assert_eq(&result, &expected);
     }
 }
 


### PR DESCRIPTION
With input like this:
```
# a long root node
## a
## b
## c
```

Here is the error we have:
```
$ astree vertical -i width_parent.md

thread 'main' panicked at 'index out of bounds: the len is 19 but the index is 18446744073709551614', /Users/yuchen/.cargo/registry/src/github.com-1ecc6299db9ec823/astree-0.2.1/src/tree/vertical.rs:179:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After the fix:

        ┌──────────────────┐
        │ a long root node │
        └────────┬─────────┘
          ┌──────┼──────┐   
        ┌─┴─┐  ┌─┴─┐  ┌─┴─┐ 
        │ a │  │ b │  │ c │ 
        └───┘  └───┘  └───┘ 